### PR TITLE
fix(content): prevent search query reset while typing.

### DIFF
--- a/client/src/containers/Header.tsx
+++ b/client/src/containers/Header.tsx
@@ -9,11 +9,10 @@ import { usePathname, useRouter } from 'next/navigation';
 import { ReactNode, useContext, useEffect, useState } from 'react';
 
 import ContentOptions from '@/components/ContentOptions';
-import { Auth } from '@/context/AuthContext';
 import useIsScrolling from '@/hooks/useIsScrolling';
+import DesktopInputfield from './DesktopInputfield';
 import DesktopSearchContainer from './DesktopSearchContainer';
 import ProfileContainer from './ProfileContainer';
-import DesktopInputfield from './DesktopInputfield';
 
 type Props = {
     username: string | undefined;
@@ -28,13 +27,12 @@ const Header = ({ children, username }: Props) => {
     const pathname = usePathname();
     const router = useRouter();
 
+    useEffect(() => {
+        setOpenInput(false);
+    }, [pathname]);
+
     // This conditions is used for conditionally rendering the menu options.
     const pathNameConditions = !pathname.includes('/content') && !pathname.includes('/search');
-
-    // Resets the search query when this page is opened.
-    useEffect(() => {
-        if (pathname.includes('/content')) inputContext?.setInput('');
-    }, [pathname, inputContext]);
 
     return (
         <>

--- a/client/src/context/SearchContext.tsx
+++ b/client/src/context/SearchContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { createContext, Dispatch, ReactNode, SetStateAction, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { createContext, Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react';
 
 export type SearchContextType = {
     input: string | null;
@@ -17,6 +18,11 @@ function SearchContext({ children }: { children: ReactNode }) {
     const [input, setInput] = useState<string>('');
     const [searchResults, setSearchResults] = useState<MediaItem[]>([]);
     const [error, setError] = useState<number | null>(null);
+    const pathname = usePathname();
+
+    useEffect(() => {
+        setInput('');
+    }, [pathname]);
 
     return (
         <InputContext.Provider


### PR DESCRIPTION
Users can now search content while on the `/content` page without it resetting itself to an empty string. Fixes #87